### PR TITLE
Fix flaky tests 1

### DIFF
--- a/api/test/db/LibraryRecommendationsDaoSpec.scala
+++ b/api/test/db/LibraryRecommendationsDaoSpec.scala
@@ -28,7 +28,7 @@ class LibraryRecommendationsDaoSpec extends  DependencySpec {
       }
     }
   }
-  
+
   "no-op if nothing to upgrade" in {
     val project = createProject(org)
     libraryRecommendationsDao.forProject(project) must be(Nil)
@@ -59,7 +59,7 @@ class LibraryRecommendationsDaoSpec extends  DependencySpec {
   }
 
   "Prefers latest production release even when more recent beta release is available" in {
-    val (library, libraryVersions) = createLibraryWithMultipleVersions(org)(
+    val (library, libraryVersions) = createLibraryWithMultipleVersions(org,
       versions = Seq("1.0.0", "1.0.2-RC1", "1.0.1")
     )
     val project = createProject(org)

--- a/api/test/util/DependencySpec.scala
+++ b/api/test/util/DependencySpec.scala
@@ -182,7 +182,7 @@ trait DependencySpec extends FlowPlaySpec with Factories {
 
   def createProjectForm(
     org: Organization = createOrganization()
-  ) = {
+  ): ProjectForm = {
     ProjectForm(
       organization = org.key,
       name = createTestName(),

--- a/api/test/util/DependencySpec.scala
+++ b/api/test/util/DependencySpec.scala
@@ -40,7 +40,7 @@ trait DependencySpec extends FlowPlaySpec with Factories {
   val random = Random()
 
   import scala.language.implicitConversions
-  implicit def toUserReference(user: User) = UserReference(id = user.id)
+  implicit def toUserReference(user: User): UserReference = UserReference(id = user.id)
 
   lazy val systemUser = createUser()
 
@@ -362,9 +362,8 @@ trait DependencySpec extends FlowPlaySpec with Factories {
   }
 
   def createLibraryWithMultipleVersions(
-    org: Organization
-  ) (
-    implicit versions: Seq[String] = Seq("1.0.0", "1.0.1", "1.0.2")
+    org: Organization,
+    versions: Seq[String] = Seq("1.0.0", "1.0.1", "1.0.2")
   ): (Library, Seq[LibraryVersion]) = {
     val library = createLibrary(org)(createLibraryForm(org).copy(version = None))
     (


### PR DESCRIPTION
This is the first PR in the series of those fixing flaky tests in `dependency`.

The remaining that I've found so far:

ItemsDaoSpec.scala
- line 128 - finds `Nil` instead of expected
- supports projects
- supports libraries