### PR TITLE
use a regex to parse build.sbt dependencies

### DIFF
--- a/api/app/lib/SimpleScalaParser.scala
+++ b/api/app/lib/SimpleScalaParser.scala
@@ -57,56 +57,23 @@ trait SimpleScalaParser {
     value.replaceAll( "//.*|(\"(?:\\\\[^\"]|\\\\\"|.)*?\")|(?s)/\\*.*?\\*/", "$1 " ).trim
   }
 
-
   def parseLibraries(): Seq[Artifact] = {
-    lines.
-      filter(_.replaceAll("%%", "%").split("%").size >= 2).
-      filter(!_.startsWith(".dependsOn")).
-      map(_.stripSuffix(",")).
-      map(_.trim).
-      map {
-        toArtifacts(_)
-      }.flatten.distinct.sortBy { l => (l.groupId, l.artifactId, l.version) }
-  }
+    val moduleIdRegex = """"([\w.-]+)"\s*(%{1,3})\s*"([\w.-]+)"\s*%\s*("?[\w.-]+"?)""".r
 
-  def toArtifacts(value: String): Seq[Artifact] = {
-    val firstParen = value.indexOf("(")
-    val lastParen = value.lastIndexOf(")")
+    lines.flatMap { line =>
+      moduleIdRegex.findAllMatchIn(line).map { regexMatch =>
+        val groupId :: crossBuilt :: artifactId :: version :: Nil = regexMatch.subgroups
 
-    val substring = if (firstParen >= 0) {
-      value.substring(firstParen+1, lastParen)
-    } else {
-      value
-    }
-
-    substring.split(",").map(_.trim).filter(!_.isEmpty).flatMap { el =>
-      el.replaceAll("%%", "%").split("%").map(_.trim).toList match {
-        case Nil => {
-          logger.withKeyValue("value", value).warn(s"Could not parse library from value")
-          None
-        }
-        case groupId :: Nil => {
-          logger.withKeyValue("value", value).withKeyValue("group", groupId).warn(s"Could not parse library from value - only found groupId but missing artifactId and version")
-          None
-        }
-        case groupId :: artifactId :: Nil => {
-          logger.withKeyValue("value", value).withKeyValue("artifact", artifactId).withKeyValue("group", groupId).warn(s"Could not parse library from value - only found groupId and artifactId but missing version")
-          None
-        }
-        case groupId :: artifactId :: version :: _ => {
-          Some(
-            Artifact(
-              project = project,
-              path = path,
-              groupId = interpolate(groupId),
-              artifactId = interpolate(artifactId),
-              version = interpolate(version),
-              isCrossBuilt = (el.indexOf("%%") >= 0)
-            )
-          )
-        }
+        Artifact(
+          project = project,
+          path = path,
+          groupId = groupId,
+          artifactId = artifactId,
+          version = if (version.startsWith("\"")) SimpleScalaParserUtil.stripQuotes(version) else interpolate(version),
+          isCrossBuilt = crossBuilt.length > 1
+        )
       }
-    }
+    }.distinct.sortBy { l => (l.groupId, l.artifactId, l.version) }.toList
   }
 
 }


### PR DESCRIPTION
in some cases the old parsing code was broken:

https://github.com/flowcommerce/lib-scalafix/blob/1f7c06aed83ec2e214bfd33964ea3ddbdbd7ed41/build.sbt is parsed as

<img width="901" alt="image" src="https://user-images.githubusercontent.com/1713819/54451245-c459e380-4728-11e9-8150-a0b1856af4dd.png">
