### PR TITLE
Fix upgrade recommendations for sbt plugins

### DIFF
--- a/api/app/actors/ProjectActor.scala
+++ b/api/app/actors/ProjectActor.scala
@@ -167,10 +167,17 @@ class ProjectActor @javax.inject.Inject() (
 
           dependencies.librariesAndPlugins.map { libraries =>
             val projectLibraries = libraries.map { artifact =>
+              val bins = dependencies.crossBuildVersion()
+              val crossBuildVersion = {
+                if (artifact.isPlugin)
+                  bins.get(BinaryType.Sbt).orElse(bins.get(BinaryType.Scala))
+                else
+                  bins.get(BinaryType.Scala)
+              }
               projectLibrariesDao.upsert(
                 project.user,
                 artifact.toProjectLibraryForm(
-                  crossBuildVersion = dependencies.crossBuildVersion()
+                  crossBuildVersion = crossBuildVersion
                 )
               ) match {
                 case Left(errors) => {

--- a/api/app/lib/Artifact.scala
+++ b/api/app/lib/Artifact.scala
@@ -10,7 +10,8 @@ case class Artifact(
   groupId: String,
   artifactId: String,
   version: String,
-  isCrossBuilt: Boolean
+  isCrossBuilt: Boolean,
+  isPlugin: Boolean,
 ) {
 
   def toProjectLibraryForm(

--- a/api/app/lib/Artifact.scala
+++ b/api/app/lib/Artifact.scala
@@ -11,7 +11,7 @@ case class Artifact(
   artifactId: String,
   version: String,
   isCrossBuilt: Boolean,
-  isPlugin: Boolean,
+  isPlugin: Boolean = false,
 ) {
 
   def toProjectLibraryForm(

--- a/api/app/lib/Artifact.scala
+++ b/api/app/lib/Artifact.scala
@@ -11,7 +11,7 @@ case class Artifact(
   artifactId: String,
   version: String,
   isCrossBuilt: Boolean,
-  isPlugin: Boolean = false,
+  isPlugin: Boolean,
 ) {
 
   def toProjectLibraryForm(

--- a/api/test/lib/BuildSbtScalaParserSpec.scala
+++ b/api/test/lib/BuildSbtScalaParserSpec.scala
@@ -53,8 +53,8 @@ lazy val root = project
       result.binaries must contain theSameElementsAs Seq(ProjectBinaryForm(projectSummary.id, BinaryType.Scala, "2.11.7", "test.sbt"))
       result.libraries must be(
         Seq(
-          Artifact(projectSummary, "test.sbt", "io.flow", "lib-play-postgresql", "0.0.1-SNAPSHOT", true),
-          Artifact(projectSummary, "test.sbt", "org.postgresql", "postgresql", "9.4-1202-jdbc42", false)
+          Artifact(projectSummary, "test.sbt", "io.flow", "lib-play-postgresql", "0.0.1-SNAPSHOT", true, false),
+          Artifact(projectSummary, "test.sbt", "org.postgresql", "postgresql", "9.4-1202-jdbc42", false, false)
         )
       )
     }
@@ -78,8 +78,8 @@ lazy val root = project
       val result = BuildSbtScalaParser(projectSummary, "test.sbt", contents, logger)
       result.binaries must be(Nil)
       result.libraries must contain theSameElementsAs Seq(
-        Artifact(projectSummary, "test.sbt", "io.flow", "lib-play-postgresql", "0.0.1-SNAPSHOT", true),
-        Artifact(projectSummary, "test.sbt", "org.postgresql", "postgresql", "9.4-1202-jdbc42", false)
+        Artifact(projectSummary, "test.sbt", "io.flow", "lib-play-postgresql", "0.0.1-SNAPSHOT", true, false),
+        Artifact(projectSummary, "test.sbt", "org.postgresql", "postgresql", "9.4-1202-jdbc42", false, false)
       )
     }
   }
@@ -111,9 +111,9 @@ lazy val www = project
       val result = BuildSbtScalaParser(projectSummary, "test.sbt", contents, logger)
       result.binaries must be(Nil)
       result.libraries must contain theSameElementsAs Seq(
-        Artifact(projectSummary, "test.sbt", "io.flow", "lib-play-postgresql", "0.0.1-SNAPSHOT", true),
-        Artifact(projectSummary, "test.sbt", "io.flow", "lib-play-postgresql", "0.0.2-SNAPSHOT", true),
-        Artifact(projectSummary, "test.sbt", "org.postgresql", "postgresql", "9.4-1202-jdbc42", false)
+        Artifact(projectSummary, "test.sbt", "io.flow", "lib-play-postgresql", "0.0.1-SNAPSHOT", true, false),
+        Artifact(projectSummary, "test.sbt", "io.flow", "lib-play-postgresql", "0.0.2-SNAPSHOT", true, false),
+        Artifact(projectSummary, "test.sbt", "org.postgresql", "postgresql", "9.4-1202-jdbc42", false, false)
       )
     }
   }
@@ -136,9 +136,9 @@ lazy val avro = project
     val result = BuildSbtScalaParser(projectSummary, "test.sbt", contents, logger)
     result.binaries must be(Nil)
     result.libraries must contain theSameElementsAs Seq(
-      Artifact(projectSummary, "test.sbt", "com.typesafe.akka", "akka-cluster", "2.3.4", true),
-      Artifact(projectSummary, "test.sbt", "com.typesafe.akka", "akka-testkit", "2.3.4", true),
-      Artifact(projectSummary, "test.sbt", "org.apache.avro", "avro", "1.7.7", false)
+      Artifact(projectSummary, "test.sbt", "com.typesafe.akka", "akka-cluster", "2.3.4", true, false),
+      Artifact(projectSummary, "test.sbt", "com.typesafe.akka", "akka-testkit", "2.3.4", true, false),
+      Artifact(projectSummary, "test.sbt", "org.apache.avro", "avro", "1.7.7", false, false)
     )
   }
 
@@ -153,7 +153,7 @@ lazy val avro = project
     val result = BuildSbtScalaParser(projectSummary, "test.sbt", contents, logger)
     result.binaries must be(Nil)
     result.libraries must contain theSameElementsAs Seq(
-      Artifact(projectSummary, "test.sbt", "org.scalatest", "scalatest", "2.2.0", true)
+      Artifact(projectSummary, "test.sbt", "org.scalatest", "scalatest", "2.2.0", true, false)
     )
   }
 
@@ -179,9 +179,9 @@ lazy val commonSettings: Seq[Def.Setting[_]] = Seq(
       val result = BuildSbtScalaParser(projectSummary, "test.sbt", contents, logger)
       result.binaries must be(Nil)
       result.libraries must contain theSameElementsAs Seq(
-        Artifact(projectSummary, "test.sbt", "io.dropwizard.metrics", "metrics-core", "3.1.0", false),
-        Artifact(projectSummary, "test.sbt", "io.dropwizard.metrics", "metrics-jvm", "3.1.0", false),
-        Artifact(projectSummary, "test.sbt", "org.scalatest", "scalatest", "2.1.2", true)
+        Artifact(projectSummary, "test.sbt", "io.dropwizard.metrics", "metrics-core", "3.1.0", false, false),
+        Artifact(projectSummary, "test.sbt", "io.dropwizard.metrics", "metrics-jvm", "3.1.0", false, false),
+        Artifact(projectSummary, "test.sbt", "org.scalatest", "scalatest", "2.1.2", true, false)
       )
       result.resolverUris must contain theSameElementsAs Seq("http://repo.typesafe.com/typesafe/releases/")
     }
@@ -197,7 +197,7 @@ lazy val commonSettings: Seq[Def.Setting[_]] = Seq(
       val result = BuildSbtScalaParser(projectSummary, "test.sbt", contents, logger)
       result.binaries must be(Nil)
       result.libraries must contain theSameElementsAs Seq(
-        Artifact(projectSummary, "test.sbt", "com.typesafe.play", "play-json", "2.2.2", true)
+        Artifact(projectSummary, "test.sbt", "com.typesafe.play", "play-json", "2.2.2", true, false)
       )
       result.resolverUris must be(Nil)
     }
@@ -226,9 +226,9 @@ lazy val tests = project.settings(
       val result = BuildSbtScalaParser(projectSummary, "test.sbt", contents, logger)
       result.binaries must be(Nil)
       result.libraries must contain theSameElementsAs Seq(
-        Artifact(projectSummary, "test.sbt", "ch.epfl.scala", "scalafix-core", "V.scalafixVersion", true),
-        Artifact(projectSummary, "test.sbt", "io.flow", "lib-play-play26", "0.5.28", true),
-        Artifact(projectSummary, "test.sbt", "ch.epfl.scala", "scalafix-testkit", "V.scalafixVersion", false),
+        Artifact(projectSummary, "test.sbt", "ch.epfl.scala", "scalafix-core", "V.scalafixVersion", true, false),
+        Artifact(projectSummary, "test.sbt", "io.flow", "lib-play-play26", "0.5.28", true, false),
+        Artifact(projectSummary, "test.sbt", "ch.epfl.scala", "scalafix-testkit", "V.scalafixVersion", false, false),
       )
       result.resolverUris must be(Nil)
     }
@@ -243,7 +243,7 @@ lazy val tests = project.settings(
       val result = BuildSbtScalaParser(projectSummary, "test.sbt", contents, logger)
       result.binaries must be(Nil)
       result.libraries must contain theSameElementsAs Seq(
-        Artifact(projectSummary, "test.sbt", "io.flow", "scalafix-rules", "0.0.1", true),
+        Artifact(projectSummary, "test.sbt", "io.flow", "scalafix-rules", "0.0.1", true, false),
       )
       result.resolverUris must be(Nil)
     }
@@ -273,10 +273,10 @@ lazy val commonSettings: Seq[Def.Setting[_]] = Seq(
     "parse dependencies" in {
       val result = BuildSbtScalaParser(projectSummary, "test.sbt", contents, logger)
       result.libraries must contain theSameElementsAs Seq(
-        Artifact(projectSummary, "test.sbt", "io.flow", "lib-event-play26", "0.4.55", true),
-        Artifact(projectSummary, "test.sbt", "io.flow", "lib-postgresql-play-play26", "0.3.6", true),
-        Artifact(projectSummary, "test.sbt", "io.flow", "lib-reference-scala", "0.2.28", true),
-        Artifact(projectSummary, "test.sbt", "io.flow", "lib-log", "0.0.64", true)
+        Artifact(projectSummary, "test.sbt", "io.flow", "lib-event-play26", "0.4.55", true, false),
+        Artifact(projectSummary, "test.sbt", "io.flow", "lib-postgresql-play-play26", "0.3.6", true, false),
+        Artifact(projectSummary, "test.sbt", "io.flow", "lib-reference-scala", "0.2.28", true, false),
+        Artifact(projectSummary, "test.sbt", "io.flow", "lib-log", "0.0.64", true, false)
       )
     }
 

--- a/api/test/lib/ProjectPluginsSbtScalaParserSpec.scala
+++ b/api/test/lib/ProjectPluginsSbtScalaParserSpec.scala
@@ -44,7 +44,7 @@ addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.4.3")
 
 resolvers += Resolver.url("scoverage-bintray", url("https://dl.bintray.com/sksamuel/sbt-plugins/"))(Resolver.ivyStylePatterns)
 
-addSbtPlugin("org.scoverage" %% "sbt-scoverage" % "1.0.1")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.0.1")
 """
 
     "parse dependencies" in {
@@ -54,8 +54,8 @@ addSbtPlugin("org.scoverage" %% "sbt-scoverage" % "1.0.1")
         "https://dl.bintray.com/sksamuel/sbt-plugins/"
       )
       result.plugins must contain theSameElementsAs Seq(
-        Artifact(projectSummary, "test.sbt", "com.typesafe.play", "sbt-plugin", "2.4.3", false),
-        Artifact(projectSummary, "test.sbt", "org.scoverage", "sbt-scoverage", "1.0.1", true)
+        Artifact(projectSummary, "test.sbt", "com.typesafe.play", "sbt-plugin", "2.4.3", true, true),
+        Artifact(projectSummary, "test.sbt", "org.scoverage", "sbt-scoverage", "1.0.1", true, true)
       )
     }
 


### PR DESCRIPTION
This didn't work before because we didn't handle the cross build version for SBT. SBT plugins are cross built for Scala versions (e.g. 2.12) as well as SBT versions (e.g. 1.2.8). SBT maps this version number into a binary-compatible version. All of our projects are on SBT ABI 1.0. Older projects would be on SBT ABI 0.13. This PR puts the SBT ABI version in the crossVersion field. A more thorough solution would keep track of both the scala cross version and sbt cross version (if applicable) for a given artifact.