### PR TITLE
Update sbt provider url

### DIFF
--- a/api/app/lib/BinaryVersionProvider.scala
+++ b/api/app/lib/BinaryVersionProvider.scala
@@ -23,7 +23,7 @@ case class DefaultBinaryVersionProvider @javax.inject.Inject()(
 ) extends BinaryVersionProvider {
 
   private[this] val ScalaUrl = "https://www.scala-lang.org/download/all.html"
-  private[this] val SbtUrl = "https://dl.bintray.com/sbt/native-packages/sbt/"
+  private[this] val SbtUrl = "https://repo1.maven.org/maven2/org/scala-sbt/sbt/"
 
   override def versions(
     binary: BinaryType

--- a/api/test/lib/BinaryVersionProviderSpec.scala
+++ b/api/test/lib/BinaryVersionProviderSpec.scala
@@ -14,9 +14,8 @@ class BinaryVersionProviderSpec extends DependencySpec {
 
   "sbt" in {
     val versions = defaultBinaryVersionProvider.versions(BinaryType.Sbt).map(_.value)
-    versions.contains("0.13.8") must be(true)
-    versions.contains("0.13.9") must be(true)
     versions.contains("0.0.1") must be(false)
+    versions.contains("1.3.0") must be(true)
   }
 
   "undefined" in {


### PR DESCRIPTION
The old provider url doesn't have any sbt 1.* releases, so I'm updating the url here.
However, I don't think sbt 0.13.* is published on any maven repos, so I had to remove that test.