### PR TITLE
Upgrade libraries com.typesafe.play, io.flow

### DIFF
--- a/api/app/generated/FlowGithubV0Parsers.scala
+++ b/api/app/generated/FlowGithubV0Parsers.scala
@@ -774,6 +774,7 @@ package io.flow.github.v0.anorm.parsers {
       description: String = "description",
       url: String = "url",
       htmlUrl: String = "html_url",
+      defaultBranch: String = "default_branch",
       prefixOpt: Option[String] = None
     ): RowParser[io.flow.github.v0.models.Repository] = {
       SqlParser.long(prefixOpt.getOrElse("") + id) ~
@@ -783,8 +784,9 @@ package io.flow.github.v0.anorm.parsers {
       SqlParser.bool(prefixOpt.getOrElse("") + `private`) ~
       SqlParser.str(prefixOpt.getOrElse("") + description).? ~
       SqlParser.str(prefixOpt.getOrElse("") + url) ~
-      SqlParser.str(prefixOpt.getOrElse("") + htmlUrl) map {
-        case id ~ owner ~ name ~ fullName ~ privateInstance ~ description ~ url ~ htmlUrl => {
+      SqlParser.str(prefixOpt.getOrElse("") + htmlUrl) ~
+      SqlParser.str(prefixOpt.getOrElse("") + defaultBranch) map {
+        case id ~ owner ~ name ~ fullName ~ privateInstance ~ description ~ url ~ htmlUrl ~ defaultBranch => {
           io.flow.github.v0.models.Repository(
             id = id,
             owner = owner,
@@ -793,7 +795,8 @@ package io.flow.github.v0.anorm.parsers {
             `private` = privateInstance,
             description = description,
             url = url,
-            htmlUrl = htmlUrl
+            htmlUrl = htmlUrl,
+            defaultBranch = defaultBranch
           )
         }
       }

--- a/build.sbt
+++ b/build.sbt
@@ -28,8 +28,8 @@ lazy val lib = project
   .settings(commonSettings: _*)
   .settings(
     libraryDependencies ++= Seq(
-      "com.typesafe.play" %% "play-test" % "2.8.7",
-      "com.typesafe.play" %% "play-specs2" % "2.8.7",
+      "com.typesafe.play" %% "play-test" % "2.8.8",
+      "com.typesafe.play" %% "play-specs2" % "2.8.8",
       "org.scalatestplus.play" %% "scalatestplus-play" % "5.1.0",
       "org.specs2" %% "specs2-core" % "4.10.6",
     )
@@ -54,11 +54,11 @@ lazy val api = project
       ws,
       guice,
       "com.sendgrid" % "sendgrid-java" % "4.7.1",
-      "io.flow" %% "lib-event-sync-play28" % "0.5.25",
-      "io.flow" %% "lib-play-graphite-play28" % "0.1.90",
-      "io.flow" %% "lib-log" % "0.1.36",
-      "io.flow" %% "lib-usage-play28" % "0.1.57",
-      "io.flow" %% "lib-test-utils-play28" % "0.1.27" % Test,
+      "io.flow" %% "lib-event-sync-play28" % "0.5.27",
+      "io.flow" %% "lib-play-graphite-play28" % "0.1.92",
+      "io.flow" %% "lib-log" % "0.1.38",
+      "io.flow" %% "lib-usage-play28" % "0.1.59",
+      "io.flow" %% "lib-test-utils-play28" % "0.1.29" % Test,
       "net.sourceforge.htmlcleaner" % "htmlcleaner" % "2.24",
       "org.postgresql" % "postgresql" % "42.2.19",
       "org.apache.commons" % "commons-text" % "1.9",
@@ -96,7 +96,7 @@ lazy val www = project
       "org.webjars" % "font-awesome" % "5.15.2",
       "org.webjars" % "jquery" % "3.6.0",
       "org.webjars.bower" % "bootstrap-social" % "5.1.1",
-      "io.flow" %% "lib-test-utils-play28" % "0.1.27" % Test,
+      "io.flow" %% "lib-test-utils-play28" % "0.1.29" % Test,
       compilerPlugin("com.github.ghik" %% "silencer-plugin" % "1.7.3" cross CrossVersion.full),
       "com.github.ghik" %% "silencer-lib" % "1.7.3" % Provided cross CrossVersion.full
     ),
@@ -116,7 +116,7 @@ val credsToUse = Option(System.getenv("ARTIFACTORY_USERNAME")) match {
 lazy val commonSettings: Seq[Setting[_]] = Seq(
   name ~= ("dependency-" + _),
   libraryDependencies ++= Seq(
-    "io.flow" %% "lib-play-play28" % "0.6.33",
+    "io.flow" %% "lib-play-play28" % "0.6.35",
     "com.typesafe.play" %% "play-json-joda" % "2.9.2",
     "com.typesafe.play" %% "play-json" % "2.9.2"
   ),

--- a/generated/app/FlowGithubV0Client.scala
+++ b/generated/app/FlowGithubV0Client.scala
@@ -197,7 +197,8 @@ package io.flow.github.v0.models {
     `private`: Boolean,
     description: _root_.scala.Option[String] = None,
     url: String,
-    htmlUrl: String
+    htmlUrl: String,
+    defaultBranch: String
   )
 
   final case class Tag(
@@ -1387,7 +1388,8 @@ package io.flow.github.v0.models {
         description <- (__ \ "description").readNullable[String]
         url <- (__ \ "url").read[String]
         htmlUrl <- (__ \ "html_url").read[String]
-      } yield Repository(id, owner, name, fullName, `private`, description, url, htmlUrl)
+        defaultBranch <- (__ \ "default_branch").read[String]
+      } yield Repository(id, owner, name, fullName, `private`, description, url, htmlUrl, defaultBranch)
     }
 
     def jsObjectRepository(obj: io.flow.github.v0.models.Repository): play.api.libs.json.JsObject = {
@@ -1398,7 +1400,8 @@ package io.flow.github.v0.models {
         "full_name" -> play.api.libs.json.JsString(obj.fullName),
         "private" -> play.api.libs.json.JsBoolean(obj.`private`),
         "url" -> play.api.libs.json.JsString(obj.url),
-        "html_url" -> play.api.libs.json.JsString(obj.htmlUrl)
+        "html_url" -> play.api.libs.json.JsString(obj.htmlUrl),
+        "default_branch" -> play.api.libs.json.JsString(obj.defaultBranch)
       ) ++ (obj.description match {
         case None => play.api.libs.json.Json.obj()
         case Some(x) => play.api.libs.json.Json.obj("description" -> play.api.libs.json.JsString(x))
@@ -2014,7 +2017,7 @@ package io.flow.github.v0 {
       override def getReadme(
         owner: String,
         repo: String,
-        ref: String = "master",
+        ref: String = "main",
         requestHeaders: Seq[(String, String)] = Nil
       )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[io.flow.github.v0.models.Contents] = {
         val queryParameters = Seq(
@@ -2033,7 +2036,7 @@ package io.flow.github.v0 {
         owner: String,
         repo: String,
         path: String,
-        ref: String = "master",
+        ref: String = "main",
         requestHeaders: Seq[(String, String)] = Nil
       )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[io.flow.github.v0.models.Contents] = {
         val queryParameters = Seq(
@@ -2533,7 +2536,7 @@ package io.flow.github.v0 {
     def getReadme(
       owner: String,
       repo: String,
-      ref: String = "master",
+      ref: String = "main",
       requestHeaders: Seq[(String, String)] = Nil
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[io.flow.github.v0.models.Contents]
 
@@ -2541,7 +2544,7 @@ package io.flow.github.v0 {
       owner: String,
       repo: String,
       path: String,
-      ref: String = "master",
+      ref: String = "main",
       requestHeaders: Seq[(String, String)] = Nil
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[io.flow.github.v0.models.Contents]
   }


### PR DESCRIPTION
- com.typesafe.play
  - play-specs2 (2.8.7 => 2.8.8)
  - play-test (2.8.7 => 2.8.8)
- io.flow
  - lib-event-sync-play28 (0.5.25 => 0.5.27)
  - lib-log (0.1.36 => 0.1.38)
  - lib-play-graphite-play28 (0.1.90 => 0.1.92)
  - lib-play-play28 (0.6.33 => 0.6.35)
  - lib-test-utils-play28 (0.1.27 => 0.1.29)
  - lib-usage-play28 (0.1.57 => 0.1.59)