### PR TITLE
Suggest version upgrades when old version is missing

### DIFF
--- a/api/app/db/InternalProjectLibrariesDao.scala
+++ b/api/app/db/InternalProjectLibrariesDao.scala
@@ -7,6 +7,7 @@ import io.flow.common.v0.models.UserReference
 import com.google.inject.Provider
 import db.generated.ProjectLibraryForm
 import io.flow.dependency.actors.ProjectActor
+import io.flow.util.Version
 
 case class InternalProjectLibrary(db: generated.ProjectLibrary) {
   val id: String = db.id
@@ -14,6 +15,12 @@ case class InternalProjectLibrary(db: generated.ProjectLibrary) {
   val projectId: String = db.projectId
   val groupId: String = db.groupId
   val artifactId: String = db.artifactId
+
+  def sortKey =
+    db.crossBuildVersion match {
+      case None => Version(db.version).sortKey
+      case Some(crossBuildVersion) => Version(s"${db.version}-$crossBuildVersion").sortKey
+    }
 }
 
 @Singleton

--- a/api/app/db/LibraryRecommendationsDao.scala
+++ b/api/app/db/LibraryRecommendationsDao.scala
@@ -32,7 +32,7 @@ class LibraryRecommendationsDao @Inject()(
       orderBy = None,
     ).foreach { projectLibrary =>
       projectLibrary.db.libraryId.flatMap { libraryId => librariesDaoProvider.get.findById(auth, libraryId) }.map { library =>
-        val recentVersions = versionsGreaterThan(auth, library, projectLibrary.db.version)
+        val recentVersions = versionsGreaterThan(auth, library, projectLibrary)
         recommend(projectLibrary, recentVersions).map { v =>
           recommendations ++= Seq(
             LibraryRecommendation(
@@ -66,12 +66,12 @@ class LibraryRecommendationsDao @Inject()(
   private[this] def versionsGreaterThan(
     auth: Authorization,
     library: Library,
-    version: String
+    projectLibrary: InternalProjectLibrary,
   ): Seq[LibraryVersion] = {
     libraryVersionsDaoProvider.get.findAll(
       auth,
       libraryId = Some(library.id),
-      greaterThanVersion = Some(version),
+      greaterThanSortKey = Some(projectLibrary.sortKey),
       limit = None
     )
   }

--- a/api/app/db/LibraryRecommendationsDao.scala
+++ b/api/app/db/LibraryRecommendationsDao.scala
@@ -71,6 +71,7 @@ class LibraryRecommendationsDao @Inject()(
     libraryVersionsDaoProvider.get.findAll(
       auth,
       libraryId = Some(library.id),
+      // we don't use greaterThanVersion because it assumes the current version is present in the DB
       greaterThanSortKey = Some(projectLibrary.sortKey),
       limit = None
     )

--- a/api/app/db/LibraryVersionsDao.scala
+++ b/api/app/db/LibraryVersionsDao.scala
@@ -170,6 +170,7 @@ class LibraryVersionsDao @Inject()(
     version: Option[String] = None,
     crossBuildVersion: Option[Option[String]] = None,
     greaterThanVersion: Option[String] = None,
+    greaterThanSortKey: Option[String] = None,
     limit: Option[Long],
     offset: Long = 0
   ): Seq[LibraryVersion] = {
@@ -182,6 +183,7 @@ class LibraryVersionsDao @Inject()(
         version = version,
         crossBuildVersion = crossBuildVersion,
         greaterThanVersion = greaterThanVersion,
+        greaterThanSortKey = greaterThanSortKey,
         limit = limit,
         offset = offset
       )
@@ -196,6 +198,7 @@ class LibraryVersionsDao @Inject()(
     version: Option[String] = None,
     crossBuildVersion: Option[Option[String]] = None,
     greaterThanVersion: Option[String] = None,
+    greaterThanSortKey: Option[String] = None,
     orderBy: OrderBy = OrderBy("-library_versions.sort_key, library_versions.created_at"),
     limit: Option[Long],
     offset: Long = 0
@@ -241,6 +244,7 @@ class LibraryVersionsDao @Inject()(
         }
       ).
       bind("greater_than_version", greaterThanVersion).
+      greaterThan("library_versions.sort_key", greaterThanSortKey).
       as(
         io.flow.dependency.v0.anorm.parsers.LibraryVersion.parser().*
       )

--- a/api/app/lib/Recommendations.scala
+++ b/api/app/lib/Recommendations.scala
@@ -11,7 +11,7 @@ object Recommendations {
     * found)
     */
   def version(current: VersionForm, others: Seq[VersionForm]): Option[String] = {
-    val currentTag = Version(current.version)
+    val currentTag = Version(current.version) // TODO: are we missing crossBuildVersion here?
 
     others.
       filter(_ != current).

--- a/api/test/db/LibraryRecommendationsDaoSpec.scala
+++ b/api/test/db/LibraryRecommendationsDaoSpec.scala
@@ -1,5 +1,6 @@
 package db
 
+import io.flow.util.Constants
 import org.scalatest.concurrent.{Eventually, IntegrationPatience}
 import org.scalatest.time.{Millis, Seconds, Span}
 import util.DependencySpec
@@ -62,6 +63,19 @@ class LibraryRecommendationsDaoSpec extends DependencySpec
       )
     }
   }
+
+  "suggests upgrade even if current version is missing" in {
+    val (_, libraryVersions) = createLibraryWithMultipleVersions(org)
+    val project = createProject(org)
+    val oldest = libraryVersions.head
+
+    addLibraryVersion(project, oldest)
+    libraryVersionsDao.delete(Constants.SystemUser, oldest)
+    eventually {
+      libraryRecommendationsDao.forProject(project) must not be (Nil)
+    }
+  }
+
 
   "Prefers latest production release even when more recent beta release is available" in {
     val (library, libraryVersions) = createLibraryWithMultipleVersions(org)(


### PR DESCRIPTION
In cases where `library_versions` does not contain a record for the
current version of a library/dependency, Dependency does not recommend
any upgrades. This happens because we do a join with `library_versions`
to find the sort key of the current version.

We have enough information to construct the sort key without a join, so
this PR fixes that.

This was discovered while investigating why, when most of Flow's projects
depend on `com.typesafe.play.sbt-plugin` 2.8.5, and Dependency knows
about 2.8.11, the upgrade isn't recommended.

As an aside, in the future we should drop using raw `Version` everywhere and use `ArtifactVersion` which knows about cross builds