### PR TITLE
Upgrade libraries

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -106,8 +106,7 @@ lazy val commonSettings: Seq[Setting[_]] = Seq(
   name ~= ("dependency-" + _),
   libraryDependencies ++= Seq(
     "io.flow" %% "lib-play-play28" % "0.7.77",
-    "com.typesafe.play" %% "play-json-joda" % "2.10.1",
-    "com.typesafe.play" %% "play-json" % "2.10.1"
+    "com.typesafe.play" %% "play-json-joda" % "2.9.4",
   ),
   scalacOptions ++= allScalacOptions,
   credentials += credsToUse,

--- a/build.sbt
+++ b/build.sbt
@@ -46,7 +46,7 @@ lazy val api = project
   .enablePlugins(JavaAppPackaging, JavaAgent)
   .settings(commonSettings: _*)
   .settings(
-    javaAgents += "com.datadoghq" % "dd-java-agent" % "1.20.0",
+    javaAgents += "com.datadoghq" % "dd-java-agent" % "1.20.1",
     routesImport += "io.flow.dependency.v0.Bindables.Core._",
     routesImport += "io.flow.dependency.v0.Bindables.Models._",
     routesGenerator := InjectedRoutesGenerator,
@@ -56,11 +56,11 @@ lazy val api = project
       ws,
       guice,
       "com.sendgrid" % "sendgrid-java" % "4.7.1",
-      "io.flow" %% "lib-event-sync-play28" % "0.6.25",
-      "io.flow" %% "lib-metrics-play28" % "1.0.62",
-      "io.flow" %% "lib-log" % "0.1.99",
-      "io.flow" %% "lib-usage-play28" % "0.2.27",
-      "io.flow" %% "lib-test-utils-play28" % "0.2.7" % Test,
+      "io.flow" %% "lib-event-sync-play28" % "0.6.27",
+      "io.flow" %% "lib-metrics-play28" % "1.0.65",
+      "io.flow" %% "lib-log" % "0.2.2",
+      "io.flow" %% "lib-usage-play28" % "0.2.29",
+      "io.flow" %% "lib-test-utils-play28" % "0.2.11" % Test,
       "net.sourceforge.htmlcleaner" % "htmlcleaner" % "2.29",
       "org.postgresql" % "postgresql" % "42.6.0",
       "org.apache.commons" % "commons-text" % "1.10.0"
@@ -79,7 +79,7 @@ lazy val www = project
   .enablePlugins(SbtWeb)
   .settings(commonSettings: _*)
   .settings(
-    javaAgents += "com.datadoghq" % "dd-java-agent" % "1.20.0",
+    javaAgents += "com.datadoghq" % "dd-java-agent" % "1.20.1",
     routesImport += "io.flow.dependency.v0.Bindables.Core._",
     routesImport += "io.flow.dependency.v0.Bindables.Models._",
     routesGenerator := InjectedRoutesGenerator,
@@ -92,7 +92,7 @@ lazy val www = project
       "org.webjars" % "font-awesome" % "6.4.2",
       "org.webjars" % "jquery" % "3.7.1",
       "org.webjars.bower" % "bootstrap-social" % "5.1.1",
-      "io.flow" %% "lib-test-utils-play28" % "0.2.7" % Test
+      "io.flow" %% "lib-test-utils-play28" % "0.2.11" % Test
     ),
     scalacOptions ++= allScalacOptions
   )
@@ -105,9 +105,9 @@ val credsToUse = Option(System.getenv("ARTIFACTORY_USERNAME")) match {
 lazy val commonSettings: Seq[Setting[_]] = Seq(
   name ~= ("dependency-" + _),
   libraryDependencies ++= Seq(
-    "io.flow" %% "lib-play-play28" % "0.7.75",
-    "com.typesafe.play" %% "play-json-joda" % "2.9.4",
-    "com.typesafe.play" %% "play-json" % "2.9.4"
+    "io.flow" %% "lib-play-play28" % "0.7.77",
+    "com.typesafe.play" %% "play-json-joda" % "2.10.1",
+    "com.typesafe.play" %% "play-json" % "2.10.1"
   ),
   scalacOptions ++= allScalacOptions,
   credentials += credsToUse,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -19,7 +19,7 @@ addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % "0.4.1")
 
 resolvers += "Flow Plugins" at "https://flow.jfrog.io/flow/plugins-release/"
 
-addSbtPlugin("io.flow" % "sbt-flow-linter" % "0.0.40")
+addSbtPlugin("io.flow" % "sbt-flow-linter" % "0.0.41")
 
 // Resolve scala-xml version dependency mismatch, see https://github.com/sbt/sbt/issues/7007
 ThisBuild / libraryDependencySchemes ++= Seq(


### PR DESCRIPTION
- com.datadoghq
  - dd-java-agent (1.20.0 => 1.20.1)
- com.typesafe.play
  - play-json (2.9.4 => 2.10.1)
  - play-json-joda (2.9.4 => 2.10.1)
- io.flow
  - lib-event-sync-play28 (0.6.25 => 0.6.27)
  - lib-log (0.1.99 => 0.2.2)
  - lib-metrics-play28 (1.0.62 => 1.0.65)
  - lib-play-play28 (0.7.75 => 0.7.77)
  - lib-test-utils-play28 (0.2.7 => 0.2.11)
  - lib-usage-play28 (0.2.27 => 0.2.29)
  - sbt-flow-linter (0.0.40 => 0.0.41)