### PR TITLE
FIN-1538: Update trueup related API Builder specs

### DIFF
--- a/.apibuilder/.tracked_files
+++ b/.apibuilder/.tracked_files
@@ -3,13 +3,11 @@ flow:
   common:
     anorm_2_8_parsers:
     - api/app/generated/FlowCommonV0Conversions.scala
-    - api/app/generated/FlowCommonV0Parsers.scala
     play_2_8_client:
     - generated/app/FlowCommonV0Client.scala
   dependency:
     anorm_2_8_parsers:
     - api/app/generated/FlowDependencyV0Conversions.scala
-    - api/app/generated/FlowDependencyV0Parsers.scala
     play_2_8_client:
     - generated/app/FlowDependencyV0Client.scala
     play_2_x_routes:
@@ -23,13 +21,11 @@ flow:
   error:
     anorm_2_8_parsers:
     - api/app/generated/FlowErrorV0Conversions.scala
-    - api/app/generated/FlowErrorV0Parsers.scala
     play_2_8_client:
     - generated/app/FlowErrorV0Client.scala
   github:
     anorm_2_8_parsers:
     - api/app/generated/FlowGithubV0Conversions.scala
-    - api/app/generated/FlowGithubV0Parsers.scala
     play_2_8_client:
     - generated/app/FlowGithubV0Client.scala
   github-oauth:


### PR DESCRIPTION
We moved shared trueup models to the public trueup.json spec. Note we also standardized on trueup as a single word. No functional change - just renaming