### PR TITLE
FDN-2272: Upgrade libraries

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -46,7 +46,7 @@ lazy val api = project
   .enablePlugins(JavaAppPackaging, JavaAgent)
   .settings(commonSettings: _*)
   .settings(
-    javaAgents += "com.datadoghq" % "dd-java-agent" % "1.31.2",
+    javaAgents += "com.datadoghq" % "dd-java-agent" % "1.32.0",
     routesImport += "io.flow.dependency.v0.Bindables.Core._",
     routesImport += "io.flow.dependency.v0.Bindables.Models._",
     routesGenerator := InjectedRoutesGenerator,
@@ -58,11 +58,11 @@ lazy val api = project
       "com.google.inject.extensions" % "guice-assistedinject" % "5.1.0",
       "org.projectlombok" % "lombok" % "1.18.32" % "provided",
       "com.sendgrid" % "sendgrid-java" % "4.7.1",
-      "io.flow" %% "lib-event-sync-play28" % "0.6.45",
-      "io.flow" %% "lib-metrics-play28" % "1.0.84",
-      "io.flow" %% "lib-log" % "0.2.16",
-      "io.flow" %% "lib-usage-play28" % "0.2.42",
-      "io.flow" %% "lib-test-utils-play28" % "0.2.28" % Test,
+      "io.flow" %% "lib-event-sync-play28" % "0.6.47",
+      "io.flow" %% "lib-metrics-play28" % "1.0.85",
+      "io.flow" %% "lib-log" % "0.2.17",
+      "io.flow" %% "lib-usage-play28" % "0.2.44",
+      "io.flow" %% "lib-test-utils-play28" % "0.2.29" % Test,
       "net.sourceforge.htmlcleaner" % "htmlcleaner" % "2.29",
       "org.postgresql" % "postgresql" % "42.7.3",
       "org.apache.commons" % "commons-text" % "1.11.0",
@@ -80,7 +80,7 @@ lazy val www = project
   .enablePlugins(SbtWeb)
   .settings(commonSettings: _*)
   .settings(
-    javaAgents += "com.datadoghq" % "dd-java-agent" % "1.31.2",
+    javaAgents += "com.datadoghq" % "dd-java-agent" % "1.32.0",
     routesImport += "io.flow.dependency.v0.Bindables.Core._",
     routesImport += "io.flow.dependency.v0.Bindables.Models._",
     routesGenerator := InjectedRoutesGenerator,
@@ -92,10 +92,10 @@ lazy val www = project
       "org.projectlombok" % "lombok" % "1.18.32" % "provided",
       "org.webjars" %% "webjars-play" % "3.0.1",
       "org.webjars" % "bootstrap" % "3.4.1",
-      "org.webjars" % "font-awesome" % "6.5.1",
+      "org.webjars" % "font-awesome" % "6.5.2",
       "org.webjars" % "jquery" % "3.7.1",
       "org.webjars.bower" % "bootstrap-social" % "5.1.1",
-      "io.flow" %% "lib-test-utils-play28" % "0.2.28" % Test,
+      "io.flow" %% "lib-test-utils-play28" % "0.2.29" % Test,
     ),
     scalacOptions ++= allScalacOptions,
   )
@@ -115,7 +115,7 @@ lazy val commonSettings: Seq[Setting[_]] = Seq(
   scalafmtOnCompile := true,
   name ~= ("dependency-" + _),
   libraryDependencies ++= Seq(
-    "io.flow" %% "lib-play-play28" % "0.7.97",
+    "io.flow" %% "lib-play-play28" % "0.7.98",
     "com.typesafe.play" %% "play-json-joda" % "2.9.4",
   ),
   Test / javaOptions ++= Seq(


### PR DESCRIPTION
- com.datadoghq
  - dd-java-agent (1.31.2 => 1.32.0)
- io.flow
  - lib-event-sync-play28 (0.6.45 => 0.6.47)
  - lib-log (0.2.16 => 0.2.17)
  - lib-metrics-play28 (1.0.84 => 1.0.85)
  - lib-play-play28 (0.7.97 => 0.7.98)
  - lib-test-utils-play28 (0.2.28 => 0.2.29)
  - lib-usage-play28 (0.2.42 => 0.2.44)
- org.webjars
  - font-awesome (6.5.1 => 6.5.2)