### PR TITLE
FDN-2371: Upgrade libraries com.datadoghq, io.flow

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -48,7 +48,7 @@ lazy val api = project
   .enablePlugins(JavaAppPackaging, JavaAgent)
   .settings(commonSettings: _*)
   .settings(
-    javaAgents += "com.datadoghq" % "dd-java-agent" % "1.33.0",
+    javaAgents += "com.datadoghq" % "dd-java-agent" % "1.34.0",
     routesImport += "io.flow.dependency.v0.Bindables.Core._",
     routesImport += "io.flow.dependency.v0.Bindables.Models._",
     routesGenerator := InjectedRoutesGenerator,
@@ -60,11 +60,11 @@ lazy val api = project
       "com.google.inject.extensions" % "guice-assistedinject" % "5.1.0",
       "org.projectlombok" % "lombok" % "1.18.32" % "provided",
       "com.sendgrid" % "sendgrid-java" % "4.7.1",
-      "io.flow" %% "lib-event-sync-play28" % "0.6.49",
-      "io.flow" %% "lib-metrics-play28" % "1.0.86",
-      "io.flow" %% "lib-log" % "0.2.18",
-      "io.flow" %% "lib-usage-play28" % "0.2.45",
-      "io.flow" %% "lib-test-utils-play28" % "0.2.30" % Test,
+      "io.flow" %% "lib-event-sync-play28" % "0.6.55",
+      "io.flow" %% "lib-metrics-play28" % "1.0.89",
+      "io.flow" %% "lib-log" % "0.2.21",
+      "io.flow" %% "lib-usage-play28" % "0.2.49",
+      "io.flow" %% "lib-test-utils-play28" % "0.2.32" % Test,
       "net.sourceforge.htmlcleaner" % "htmlcleaner" % "2.29",
       "org.postgresql" % "postgresql" % "42.7.3",
       "org.apache.commons" % "commons-text" % "1.12.0",
@@ -82,7 +82,7 @@ lazy val www = project
   .enablePlugins(SbtWeb)
   .settings(commonSettings: _*)
   .settings(
-    javaAgents += "com.datadoghq" % "dd-java-agent" % "1.33.0",
+    javaAgents += "com.datadoghq" % "dd-java-agent" % "1.34.0",
     routesImport += "io.flow.dependency.v0.Bindables.Core._",
     routesImport += "io.flow.dependency.v0.Bindables.Models._",
     routesGenerator := InjectedRoutesGenerator,
@@ -97,7 +97,7 @@ lazy val www = project
       "org.webjars" % "font-awesome" % "6.5.2",
       "org.webjars" % "jquery" % "3.7.1",
       "org.webjars.bower" % "bootstrap-social" % "5.1.1",
-      "io.flow" %% "lib-test-utils-play28" % "0.2.30" % Test,
+      "io.flow" %% "lib-test-utils-play28" % "0.2.32" % Test,
     ),
     scalacOptions ++= allScalacOptions,
   )
@@ -117,7 +117,7 @@ lazy val commonSettings: Seq[Setting[_]] = Seq(
   scalafmtOnCompile := true,
   name ~= ("dependency-" + _),
   libraryDependencies ++= Seq(
-    "io.flow" %% "lib-play-play28" % "0.7.99",
+    "io.flow" %% "lib-play-play28" % "0.8.2",
     "com.typesafe.play" %% "play-json-joda" % "2.9.4",
   ),
   Test / javaOptions ++= Seq(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -17,7 +17,7 @@ addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % "0.4.1")
 
 resolvers += "Flow Plugins" at "https://flow.jfrog.io/flow/plugins-release/"
 
-addSbtPlugin("io.flow" % "sbt-flow-linter" % "0.0.55")
+addSbtPlugin("io.flow" % "sbt-flow-linter" % "0.0.56")
 
 // Resolve scala-xml version dependency mismatch, see https://github.com/sbt/sbt/issues/7007
 ThisBuild / libraryDependencySchemes ++= Seq(


### PR DESCRIPTION
- com.datadoghq
  - dd-java-agent (1.33.0 => 1.34.0)
- io.flow
  - lib-event-sync-play28 (0.6.49 => 0.6.55)
  - lib-log (0.2.18 => 0.2.21)
  - lib-metrics-play28 (1.0.86 => 1.0.89)
  - lib-play-play28 (0.7.99 => 0.8.2)
  - lib-test-utils-play28 (0.2.30 => 0.2.32)
  - lib-usage-play28 (0.2.45 => 0.2.49)
  - sbt-flow-linter (0.0.55 => 0.0.56)