### PR TITLE
FDN-2397:Upgrade scala v2.13.13 and sbt version upgrade

### DIFF
--- a/api/app/actors/TaskActor.scala
+++ b/api/app/actors/TaskActor.scala
@@ -180,7 +180,7 @@ class TaskActorSyncOrganizationLibraries @Inject() (
   ) {
   override def accepts(task: InternalTask): Boolean = {
     task.data match {
-      case _: TaskDataSyncLibrariesByPrefix => true
+      case _: TaskDataSyncOrganizationLibraries => true
       case _ => false
     }
   }

--- a/api/app/actors/TaskActor.scala
+++ b/api/app/actors/TaskActor.scala
@@ -194,7 +194,7 @@ class TaskActorSyncLibrariesByPrefix @Inject() (
   ) {
   override def accepts(task: InternalTask): Boolean = {
     task.data match {
-      case _: TaskActorSyncLibrariesByPrefix => true
+      case _: TaskDataSyncLibrariesByPrefix => true
       case _ => false
     }
   }

--- a/api/test/util/DependencySpec.scala
+++ b/api/test/util/DependencySpec.scala
@@ -12,33 +12,33 @@ import io.flow.util.{Config, IdGenerator, Random}
 
 trait DependencySpec extends FlowPlaySpec with Factories {
 
-  implicit val defaultBinaryVersionProvider = init[DefaultBinaryVersionProvider]
-  implicit val organizationsDao = init[OrganizationsDao]
-  implicit val binariesDao = init[BinariesDao]
-  implicit val binaryVersionsDao = init[BinaryVersionsDao]
-  implicit val librariesDao = init[LibrariesDao]
-  implicit val libraryVersionsDao = init[LibraryVersionsDao]
-  implicit val usersDao = init[UsersDao]
-  implicit val projectsDao = init[ProjectsDao]
-  implicit val projectLibrariesDao = init[InternalProjectLibrariesDao]
-  implicit val projectBinariesDao = init[ProjectBinariesDao]
-  implicit val githubUsersDao = init[GithubUsersDao]
-  implicit val tokensDao = init[TokensDao]
-  implicit val syncsDao = init[SyncsDao]
-  implicit val resolversDao = init[ResolversDao]
-  implicit val membershipsDao = init[MembershipsDao]
-  implicit val itemsDao = init[InternalItemsDao]
-  implicit val subscriptionsDao = init[SubscriptionsDao]
-  implicit val lastEmailsDao = init[LastEmailsDao]
-  implicit val binaryRecommendationsDao = init[BinaryRecommendationsDao]
-  implicit val libraryRecommendationsDao = init[LibraryRecommendationsDao]
-  implicit val recommendationsDao = init[RecommendationsDao]
-  implicit val userIdentifiersDao = init[UserIdentifiersDao]
-  implicit val config = init[Config]
+  implicit val defaultBinaryVersionProvider: DefaultBinaryVersionProvider = init[DefaultBinaryVersionProvider]
+  implicit val organizationsDao: OrganizationsDao = init[OrganizationsDao]
+  implicit val binariesDao: BinariesDao = init[BinariesDao]
+  implicit val binaryVersionsDao: BinaryVersionsDao = init[BinaryVersionsDao]
+  implicit val librariesDao: LibrariesDao = init[LibrariesDao]
+  implicit val libraryVersionsDao: LibraryVersionsDao = init[LibraryVersionsDao]
+  implicit val usersDao: UsersDao = init[UsersDao]
+  implicit val projectsDao: ProjectsDao = init[ProjectsDao]
+  implicit val projectLibrariesDao: InternalProjectLibrariesDao = init[InternalProjectLibrariesDao]
+  implicit val projectBinariesDao: ProjectBinariesDao = init[ProjectBinariesDao]
+  implicit val githubUsersDao: GithubUsersDao = init[GithubUsersDao]
+  implicit val tokensDao: TokensDao = init[TokensDao]
+  implicit val syncsDao: SyncsDao = init[SyncsDao]
+  implicit val resolversDao: ResolversDao = init[ResolversDao]
+  implicit val membershipsDao: MembershipsDao = init[MembershipsDao]
+  implicit val itemsDao: InternalItemsDao = init[InternalItemsDao]
+  implicit val subscriptionsDao: SubscriptionsDao = init[SubscriptionsDao]
+  implicit val lastEmailsDao: LastEmailsDao = init[LastEmailsDao]
+  implicit val binaryRecommendationsDao: BinaryRecommendationsDao = init[BinaryRecommendationsDao]
+  implicit val libraryRecommendationsDao: LibraryRecommendationsDao = init[LibraryRecommendationsDao]
+  implicit val recommendationsDao: RecommendationsDao = init[RecommendationsDao]
+  implicit val userIdentifiersDao: UserIdentifiersDao = init[UserIdentifiersDao]
+  implicit val config: Config = init[Config]
 
   val random = Random()
 
-  implicit def toUserReference(user: User) = UserReference(id = user.id)
+  implicit def toUserReference(user: User): UserReference = UserReference(id = user.id)
 
   lazy val systemUser: User = createUser()
 

--- a/build.sbt
+++ b/build.sbt
@@ -5,6 +5,7 @@ organization := "io.flow"
 ThisBuild / scalaVersion := "2.13.13"
 
 ThisBuild / libraryDependencySchemes += "org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always
+ThisBuild / libraryDependencySchemes += "org.scoverage" %% "sbt-scoverage" % VersionScheme.Always
 
 lazy val allScalacOptions = Seq(
   "-feature",

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "dependency"
 
 organization := "io.flow"
 
-ThisBuild / scalaVersion := "2.13.8"
+ThisBuild / scalaVersion := "2.13.13"
 
 ThisBuild / libraryDependencySchemes += "org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.9
+sbt.version=1.10.0

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -25,4 +25,4 @@ ThisBuild / libraryDependencySchemes ++= Seq(
 )
 
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.2")
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.0.8")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.0.11")

--- a/www/app/lib/Permissions.scala
+++ b/www/app/lib/Permissions.scala
@@ -24,7 +24,7 @@ object Permissions {
 
   object Resolver {
 
-    @nowarn
+    // @nowarn
     def delete(resolver: Resolver, user: Option[User]): Boolean = {
       // TODO
       true

--- a/www/app/lib/Permissions.scala
+++ b/www/app/lib/Permissions.scala
@@ -24,7 +24,6 @@ object Permissions {
 
   object Resolver {
 
-    // @nowarn
     def delete(resolver: Resolver, user: Option[User]): Boolean = {
       // TODO
       true


### PR DESCRIPTION
In this PR we are upgrading scala version from v2.13.10 to v2.13.13 and sbt version from v1.9.9 to v1.10.0 for which need to add type annotation in the below files

 api/app/actors/TaskActor.scala
 api/test/util/DependencySpec.scala
 www/app/lib/Permissions.scala

