### PR TITLE
FDN-2475: Upgrade libraries io.flow

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -61,11 +61,11 @@ lazy val api = project
       "com.google.inject.extensions" % "guice-assistedinject" % "5.1.0",
       "org.projectlombok" % "lombok" % "1.18.32" % "provided",
       "com.sendgrid" % "sendgrid-java" % "4.7.1",
-      "io.flow" %% "lib-event-sync-play28" % "0.6.55",
-      "io.flow" %% "lib-metrics-play28" % "1.0.89",
+      "io.flow" %% "lib-event-sync-play28" % "0.6.56",
+      "io.flow" %% "lib-metrics-play28" % "1.0.90",
       "io.flow" %% "lib-log" % "0.2.21",
-      "io.flow" %% "lib-usage-play28" % "0.2.49",
-      "io.flow" %% "lib-test-utils-play28" % "0.2.32" % Test,
+      "io.flow" %% "lib-usage-play28" % "0.2.50",
+      "io.flow" %% "lib-test-utils-play28" % "0.2.34" % Test,
       "net.sourceforge.htmlcleaner" % "htmlcleaner" % "2.29",
       "org.postgresql" % "postgresql" % "42.7.3",
       "org.apache.commons" % "commons-text" % "1.12.0",
@@ -98,7 +98,7 @@ lazy val www = project
       "org.webjars" % "font-awesome" % "6.5.2",
       "org.webjars" % "jquery" % "3.7.1",
       "org.webjars.bower" % "bootstrap-social" % "5.1.1",
-      "io.flow" %% "lib-test-utils-play28" % "0.2.32" % Test,
+      "io.flow" %% "lib-test-utils-play28" % "0.2.34" % Test,
     ),
     scalacOptions ++= allScalacOptions,
   )
@@ -118,7 +118,7 @@ lazy val commonSettings: Seq[Setting[_]] = Seq(
   scalafmtOnCompile := true,
   name ~= ("dependency-" + _),
   libraryDependencies ++= Seq(
-    "io.flow" %% "lib-play-play28" % "0.8.2",
+    "io.flow" %% "lib-play-play28" % "0.8.3",
     "com.typesafe.play" %% "play-json-joda" % "2.9.4",
   ),
   Test / javaOptions ++= Seq(


### PR DESCRIPTION
- io.flow
  - lib-event-sync-play28 (0.6.55 => 0.6.56)
  - lib-metrics-play28 (1.0.89 => 1.0.90)
  - lib-play-play28 (0.8.2 => 0.8.3)
  - lib-test-utils-play28 (0.2.32 => 0.2.34)
  - lib-usage-play28 (0.2.49 => 0.2.50)