### PR TITLE
LOG-2713: Upgrade libraries com.datadoghq, io.flow

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -49,7 +49,7 @@ lazy val api = project
   .enablePlugins(JavaAppPackaging, JavaAgent)
   .settings(commonSettings: _*)
   .settings(
-    javaAgents += "com.datadoghq" % "dd-java-agent" % "1.38.1",
+    javaAgents += "com.datadoghq" % "dd-java-agent" % "1.39.0",
     routesImport += "io.flow.dependency.v0.Bindables.Core._",
     routesImport += "io.flow.dependency.v0.Bindables.Models._",
     routesGenerator := InjectedRoutesGenerator,
@@ -61,11 +61,11 @@ lazy val api = project
       "com.google.inject.extensions" % "guice-assistedinject" % "5.1.0",
       "org.projectlombok" % "lombok" % "1.18.34" % "provided",
       "com.sendgrid" % "sendgrid-java" % "4.7.1",
-      "io.flow" %% "lib-event-sync-play28" % "0.6.62",
-      "io.flow" %% "lib-metrics-play28" % "1.0.95",
-      "io.flow" %% "lib-log" % "0.2.23",
-      "io.flow" %% "lib-usage-play28" % "0.2.55",
-      "io.flow" %% "lib-test-utils-play28" % "0.2.38" % Test,
+      "io.flow" %% "lib-event-sync-play28" % "0.6.63",
+      "io.flow" %% "lib-metrics-play28" % "1.0.96",
+      "io.flow" %% "lib-log" % "0.2.25",
+      "io.flow" %% "lib-usage-play28" % "0.2.56",
+      "io.flow" %% "lib-test-utils-play28" % "0.2.39" % Test,
       "net.sourceforge.htmlcleaner" % "htmlcleaner" % "2.29",
       "org.postgresql" % "postgresql" % "42.7.4",
       "org.apache.commons" % "commons-text" % "1.12.0",
@@ -83,7 +83,7 @@ lazy val www = project
   .enablePlugins(SbtWeb)
   .settings(commonSettings: _*)
   .settings(
-    javaAgents += "com.datadoghq" % "dd-java-agent" % "1.38.1",
+    javaAgents += "com.datadoghq" % "dd-java-agent" % "1.39.0",
     routesImport += "io.flow.dependency.v0.Bindables.Core._",
     routesImport += "io.flow.dependency.v0.Bindables.Models._",
     routesGenerator := InjectedRoutesGenerator,
@@ -98,7 +98,7 @@ lazy val www = project
       "org.webjars" % "font-awesome" % "6.5.2",
       "org.webjars" % "jquery" % "3.7.1",
       "org.webjars.bower" % "bootstrap-social" % "5.1.1",
-      "io.flow" %% "lib-test-utils-play28" % "0.2.38" % Test,
+      "io.flow" %% "lib-test-utils-play28" % "0.2.39" % Test,
     ),
     scalacOptions ++= allScalacOptions,
   )
@@ -118,7 +118,7 @@ lazy val commonSettings: Seq[Setting[_]] = Seq(
   scalafmtOnCompile := true,
   name ~= ("dependency-" + _),
   libraryDependencies ++= Seq(
-    "io.flow" %% "lib-play-play28" % "0.8.4",
+    "io.flow" %% "lib-play-play28" % "0.8.5",
     "com.typesafe.play" %% "play-json-joda" % "2.9.4",
   ),
   Test / javaOptions ++= Seq(


### PR DESCRIPTION
- com.datadoghq
  - dd-java-agent (1.38.1 => 1.39.0)
- io.flow
  - lib-event-sync-play28 (0.6.62 => 0.6.63)
  - lib-log (0.2.23 => 0.2.25)
  - lib-metrics-play28 (1.0.95 => 1.0.96)
  - lib-play-play28 (0.8.4 => 0.8.5)
  - lib-test-utils-play28 (0.2.38 => 0.2.39)
  - lib-usage-play28 (0.2.55 => 0.2.56)