### PR TITLE
FDN-3000: Upgrade libraries

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -49,7 +49,7 @@ lazy val api = project
   .enablePlugins(JavaAppPackaging, JavaAgent)
   .settings(commonSettings: _*)
   .settings(
-    javaAgents += "com.datadoghq" % "dd-java-agent" % "1.40.1",
+    javaAgents += "com.datadoghq" % "dd-java-agent" % "1.42.1",
     routesImport += "io.flow.dependency.v0.Bindables.Core._",
     routesImport += "io.flow.dependency.v0.Bindables.Models._",
     routesGenerator := InjectedRoutesGenerator,
@@ -61,11 +61,11 @@ lazy val api = project
       "com.google.inject.extensions" % "guice-assistedinject" % "5.1.0",
       "org.projectlombok" % "lombok" % "1.18.34" % "provided",
       "com.sendgrid" % "sendgrid-java" % "4.7.1",
-      "io.flow" %% "lib-event-sync-play28" % "0.6.68",
-      "io.flow" %% "lib-metrics-play28" % "1.0.97",
-      "io.flow" %% "lib-log" % "0.2.27",
-      "io.flow" %% "lib-usage-play28" % "0.2.58",
-      "io.flow" %% "lib-test-utils-play28" % "0.2.40" % Test,
+      "io.flow" %% "lib-event-sync-play28" % "0.6.69",
+      "io.flow" %% "lib-metrics-play28" % "1.1.1",
+      "io.flow" %% "lib-log" % "0.2.28",
+      "io.flow" %% "lib-usage-play28" % "0.2.59",
+      "io.flow" %% "lib-test-utils-play28" % "0.2.41" % Test,
       "net.sourceforge.htmlcleaner" % "htmlcleaner" % "2.29",
       "org.postgresql" % "postgresql" % "42.7.4",
       "org.apache.commons" % "commons-text" % "1.12.0",
@@ -83,7 +83,7 @@ lazy val www = project
   .enablePlugins(SbtWeb)
   .settings(commonSettings: _*)
   .settings(
-    javaAgents += "com.datadoghq" % "dd-java-agent" % "1.40.1",
+    javaAgents += "com.datadoghq" % "dd-java-agent" % "1.42.1",
     routesImport += "io.flow.dependency.v0.Bindables.Core._",
     routesImport += "io.flow.dependency.v0.Bindables.Models._",
     routesGenerator := InjectedRoutesGenerator,
@@ -98,7 +98,7 @@ lazy val www = project
       "org.webjars" % "font-awesome" % "6.5.2",
       "org.webjars" % "jquery" % "3.7.1",
       "org.webjars.bower" % "bootstrap-social" % "5.1.1",
-      "io.flow" %% "lib-test-utils-play28" % "0.2.40" % Test,
+      "io.flow" %% "lib-test-utils-play28" % "0.2.41" % Test,
     ),
     scalacOptions ++= allScalacOptions,
   )
@@ -118,7 +118,7 @@ lazy val commonSettings: Seq[Setting[_]] = Seq(
   scalafmtOnCompile := true,
   name ~= ("dependency-" + _),
   libraryDependencies ++= Seq(
-    "io.flow" %% "lib-play-play28" % "0.8.7",
+    "io.flow" %% "lib-play-play28" % "0.8.8",
     "com.typesafe.play" %% "play-json-joda" % "2.9.4",
   ),
   Test / javaOptions ++= Seq(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -17,7 +17,7 @@ addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % "0.4.1")
 
 resolvers += "Flow Plugins" at "https://flow.jfrog.io/flow/plugins-release/"
 
-addSbtPlugin("io.flow" % "sbt-flow-linter" % "0.0.57")
+addSbtPlugin("io.flow" % "sbt-flow-linter" % "0.0.59")
 
 // Resolve scala-xml version dependency mismatch, see https://github.com/sbt/sbt/issues/7007
 ThisBuild / libraryDependencySchemes ++= Seq(
@@ -25,4 +25,4 @@ ThisBuild / libraryDependencySchemes ++= Seq(
 )
 
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.2")
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.2.1")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.2.2")


### PR DESCRIPTION
- com.datadoghq
  - dd-java-agent (1.40.1 => 1.42.1)
- io.flow
  - lib-event-sync-play28 (0.6.68 => 0.6.69)
  - lib-log (0.2.27 => 0.2.28)
  - lib-metrics-play28 (1.0.97 => 1.1.1)
  - lib-play-play28 (0.8.7 => 0.8.8)
  - lib-test-utils-play28 (0.2.40 => 0.2.41)
  - lib-usage-play28 (0.2.58 => 0.2.59)
  - sbt-flow-linter (0.0.57 => 0.0.59)
- org.scoverage
  - sbt-scoverage (2.2.1 => 2.2.2)