### PR TITLE
FDN-3142: Upgrade libraries

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -49,7 +49,7 @@ lazy val api = project
   .enablePlugins(JavaAppPackaging, JavaAgent)
   .settings(commonSettings: _*)
   .settings(
-    javaAgents += "com.datadoghq" % "dd-java-agent" % "1.43.0",
+    javaAgents += "com.datadoghq" % "dd-java-agent" % "1.44.1",
     routesImport += "io.flow.dependency.v0.Bindables.Core._",
     routesImport += "io.flow.dependency.v0.Bindables.Models._",
     routesGenerator := InjectedRoutesGenerator,
@@ -61,14 +61,14 @@ lazy val api = project
       "com.google.inject.extensions" % "guice-assistedinject" % "5.1.0",
       "org.projectlombok" % "lombok" % "1.18.36" % "provided",
       "com.sendgrid" % "sendgrid-java" % "4.7.1",
-      "io.flow" %% "lib-event-sync-play28" % "0.6.76",
-      "io.flow" %% "lib-metrics-play28" % "1.1.3",
-      "io.flow" %% "lib-log" % "0.2.28",
-      "io.flow" %% "lib-usage-play28" % "0.2.63",
-      "io.flow" %% "lib-test-utils-play28" % "0.2.42" % Test,
+      "io.flow" %% "lib-event-sync-play28" % "0.6.79",
+      "io.flow" %% "lib-metrics-play28" % "1.1.4",
+      "io.flow" %% "lib-log" % "0.2.29",
+      "io.flow" %% "lib-usage-play28" % "0.2.64",
+      "io.flow" %% "lib-test-utils-play28" % "0.2.43" % Test,
       "net.sourceforge.htmlcleaner" % "htmlcleaner" % "2.29",
       "org.postgresql" % "postgresql" % "42.7.4",
-      "org.apache.commons" % "commons-text" % "1.12.0",
+      "org.apache.commons" % "commons-text" % "1.13.0",
     ),
     scalacOptions ++= allScalacOptions,
   )
@@ -83,7 +83,7 @@ lazy val www = project
   .enablePlugins(SbtWeb)
   .settings(commonSettings: _*)
   .settings(
-    javaAgents += "com.datadoghq" % "dd-java-agent" % "1.43.0",
+    javaAgents += "com.datadoghq" % "dd-java-agent" % "1.44.1",
     routesImport += "io.flow.dependency.v0.Bindables.Core._",
     routesImport += "io.flow.dependency.v0.Bindables.Models._",
     routesGenerator := InjectedRoutesGenerator,
@@ -95,10 +95,10 @@ lazy val www = project
       "org.projectlombok" % "lombok" % "1.18.36" % "provided",
       "org.webjars" %% "webjars-play" % "2.8.18",
       "org.webjars" % "bootstrap" % "3.4.1",
-      "org.webjars" % "font-awesome" % "6.6.0",
+      "org.webjars" % "font-awesome" % "6.7.1",
       "org.webjars" % "jquery" % "3.7.1",
       "org.webjars.bower" % "bootstrap-social" % "5.1.1",
-      "io.flow" %% "lib-test-utils-play28" % "0.2.42" % Test,
+      "io.flow" %% "lib-test-utils-play28" % "0.2.43" % Test,
     ),
     scalacOptions ++= allScalacOptions,
   )
@@ -118,7 +118,7 @@ lazy val commonSettings: Seq[Setting[_]] = Seq(
   scalafmtOnCompile := true,
   name ~= ("dependency-" + _),
   libraryDependencies ++= Seq(
-    "io.flow" %% "lib-play-play28" % "0.8.8",
+    "io.flow" %% "lib-play-play28" % "0.8.9",
     "com.typesafe.play" %% "play-json-joda" % "2.9.4",
   ),
   Test / javaOptions ++= Seq(


### PR DESCRIPTION
- com.datadoghq
  - dd-java-agent (1.43.0 => 1.44.1)
- io.flow
  - lib-event-sync-play28 (0.6.76 => 0.6.79)
  - lib-log (0.2.28 => 0.2.29)
  - lib-metrics-play28 (1.1.3 => 1.1.4)
  - lib-play-play28 (0.8.8 => 0.8.9)
  - lib-test-utils-play28 (0.2.42 => 0.2.43)
  - lib-usage-play28 (0.2.63 => 0.2.64)
- org.apache.commons
  - commons-text (1.12.0 => 1.13.0)
- org.webjars
  - font-awesome (6.6.0 => 6.7.1)