### PR TITLE
FDN-3276 webjars not working correctly with Play 2.9

### DIFF
--- a/www/app/views/main.scala.html
+++ b/www/app/views/main.scala.html
@@ -10,9 +10,9 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>@data.headTitle.getOrElse(data.title.getOrElse("dependency"))</title>
-    <link rel="stylesheet" media="screen" href="@routes.Assets.at("lib/bootstrap/css/bootstrap.min.css")">
+    <link rel="stylesheet" media="screen" href="@routes.Assets.at("lib/bootstrap/5.3.3/css/bootstrap.min.css")">
     <link rel="stylesheet" media="screen" href="@routes.Assets.at("lib/bootstrap-social/bootstrap-social.css")">
-    <link rel="stylesheet" media="screen" href="@routes.Assets.at("lib/font-awesome/css/font-awesome.min.css")">
+    <link rel="stylesheet" media="screen" href="@routes.Assets.at("lib/font-awesome/4.7.0/css/font-awesome.min.css")">
     <link rel="stylesheet" media="screen" href="@routes.Assets.at("stylesheets/main.css")">
     <link rel="shortcut icon" type="image/png" href="@routes.Assets.at("images/favicon.ico")">
   </head>
@@ -60,7 +60,7 @@
     </div>
 
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
-    <script src="@routes.Assets.at("lib/bootstrap/js/bootstrap.min.js")" type="text/javascript"></script>
+    <script src="@routes.Assets.at("lib/bootstrap/5.3.3/js/bootstrap.min.js")" type="text/javascript"></script>
     <script src="@routes.Assets.at("javascripts/util.js")" type="text/javascript"></script>
     @jsFiles.map { js =>
       <script src="@routes.Assets.at(s"javascripts/$js")" type="text/javascript"></script>


### PR DESCRIPTION
Seeing 404 errors on the page for various resources.  Adding version numbers as a hack here due to findings locally.  Note that bootstrap social brings in an earlier bootstrap version.

```
$find . -name bootstrap-social.css
./www/target/web/web-modules/main/webjars/lib/bootstrap-social/bootstrap-social.css
./www/target/web/public/main/lib/bootstrap-social/bootstrap-social.css

$ find . -name bootstrap.min.css
./www/target/web/web-modules/main/webjars/lib/bootstrap/4.0.0-beta.3/dist/css/bootstrap.min.css
./www/target/web/web-modules/main/webjars/lib/bootstrap/5.3.3/css/bootstrap.min.css
./www/target/web/public/main/lib/bootstrap/4.0.0-beta.3/dist/css/bootstrap.min.css
./www/target/web/public/main/lib/bootstrap/5.3.3/css/bootstrap.min.css

$ find . -name bootstrap.min.js
./www/target/web/web-modules/main/webjars/lib/bootstrap/4.0.0-beta.3/dist/js/bootstrap.min.js
./www/target/web/web-modules/main/webjars/lib/bootstrap/5.3.3/js/bootstrap.min.js
./www/target/web/public/main/lib/bootstrap/4.0.0-beta.3/dist/js/bootstrap.min.js
./www/target/web/public/main/lib/bootstrap/5.3.3/js/bootstrap.min.js

$ find . -name font-awesome.min.css
./www/target/web/web-modules/main/webjars/lib/font-awesome/4.7.0/css/font-awesome.min.css
./www/target/web/public/main/lib/font-awesome/4.7.0/css/font-awesome.min.css

```