### PR TITLE
FDN-3595 set maxUnavailable in Pod Disruption Budget 1

### DIFF
--- a/deploy/dependency-api/values.yaml
+++ b/deploy/dependency-api/values.yaml
@@ -30,7 +30,6 @@ deployments:
   live:
     minReplicas: 1
     maxReplicas: 1
-    maxUnavailable: 0
     AWSRole: "arn:aws:iam::479720515435:role/flow-prod-eks-production-role"
 
 nodeSelector:

--- a/deploy/dependency-www/values.yaml
+++ b/deploy/dependency-www/values.yaml
@@ -52,7 +52,6 @@ deployments:
   live:
     minReplicas: 1
     maxReplicas: 1
-    maxUnavailable: 0
     AWSRole: "arn:aws:iam::479720515435:role/flow-prod-eks-production-role"
 
 nodeSelector:


### PR DESCRIPTION
We set maxUnavailable to 1 like a default value in Pod Disruption Budget k8s object, Most of our services already have that value, but some of them don't and after next regular deployment value will be changed from 0 to 1 . Why does it matter ? it helps k8s API evict pods from the spot instances which are going to be terminated, If Pod Disruption Budget is 0 k8s API is not able to evict pods and during Node termination - pods terminated not gracefully which could cause to spike of latencies/slow responses/errors.