### PR TITLE
FDN-3863: Upgrade libraries io.flow, org.apache.commons

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -61,15 +61,15 @@ lazy val api = project
       ws,
       "org.projectlombok" % "lombok" % "1.18.38" % Provided,
       "com.sendgrid" % "sendgrid-java" % "4.10.3",
-      "io.flow" %% "lib-play-play29" % "0.8.20",
-      "io.flow" %% "lib-postgresql-play29" % "0.2.90",
-      "io.flow" %% "lib-postgresql-play-play29" % "0.6.0" % Runtime, // Module
-      "io.flow" %% "lib-log-play29" % "0.2.42",
-      "io.flow" %% "lib-usage-play29" % "0.2.75",
-      "io.flow" %% "lib-test-utils-play29" % "0.2.53" % Test,
+      "io.flow" %% "lib-play-play29" % "0.8.34",
+      "io.flow" %% "lib-postgresql-play29" % "0.2.91",
+      "io.flow" %% "lib-postgresql-play-play29" % "0.6.3" % Runtime, // Module
+      "io.flow" %% "lib-log-play29" % "0.2.43",
+      "io.flow" %% "lib-usage-play29" % "0.2.76",
+      "io.flow" %% "lib-test-utils-play29" % "0.2.54" % Test,
       "net.sourceforge.htmlcleaner" % "htmlcleaner" % "2.29",
       "org.postgresql" % "postgresql" % "42.7.4",
-      "org.apache.commons" % "commons-text" % "1.13.1",
+      "org.apache.commons" % "commons-text" % "1.14.0",
     ),
     scalacOptions ++= allScalacOptions,
   )
@@ -96,8 +96,8 @@ lazy val www = project
       "org.webjars" % "bootstrap" % "3.4.1" % Runtime,
       "org.webjars" % "jquery" % "3.7.1" % Runtime,
       "org.webjars" % "bootstrap-social" % "5.0.0" % Runtime,
-      "io.flow" %% "lib-play-play29" % "0.8.20",
-      "io.flow" %% "lib-test-utils-play29" % "0.2.53" % Test,
+      "io.flow" %% "lib-play-play29" % "0.8.34",
+      "io.flow" %% "lib-test-utils-play29" % "0.2.54" % Test,
     ),
     scalacOptions ++= allScalacOptions,
   )


### PR DESCRIPTION
- io.flow
  - lib-log-play29 (0.2.42 => 0.2.43)
  - lib-play-play29 (0.8.20 => 0.8.34)
  - lib-postgresql-play-play29 (0.6.0 => 0.6.3)
  - lib-postgresql-play29 (0.2.90 => 0.2.91)
  - lib-test-utils-play29 (0.2.53 => 0.2.54)
  - lib-usage-play29 (0.2.75 => 0.2.76)
- org.apache.commons
  - commons-text (1.13.1 => 1.14.0)